### PR TITLE
Fix NoReverseMatch error for reports link

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -16,9 +16,9 @@
                 <li class="nav-item">
                     <a class="nav-link" href="{% url 'dashboard:dashboard' %}">Dashboard</a>
                 </li>
-                {% if user.role == 'super_admin' or user.role == 'manager' %}
+          {% if user.role == 'lead' or user.role == 'manager' %}
                     <li class="nav-item">
-                        <a class="nav-link" href="{% url 'reports:report' %}">Reports</a>
+              <a class="nav-link" href="{% url 'reports:daily_report' %}">Reports</a>
                     </li>
                     <li class="nav-item">
                         <a class="nav-link" href="{% url 'dropdowns:dropdown_list' %}">Dropdowns</a>


### PR DESCRIPTION
This commit fixes a `NoReverseMatch` error that occurred when rendering the navigation bar. The 'reports:report' URL name was not found because it was replaced by more specific report URLs (daily, weekly, monthly).

- Updated the 'Reports' link in `templates/base.html` to point to 'reports:daily_report' as a default.
- Corrected the role check in the template to use 'lead' instead of 'super_admin'.